### PR TITLE
Added *.pyc and eggs-info to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ src/senaite.api
 src/senaite.core
 dist
 build
+*.pyc
+*.egg-info


### PR DESCRIPTION
Exclude the files that end with .pyc and egg-info folders