### PR TITLE
Allow to pass in a catalog brain or instance to initialize a SuperModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </a>
 
   <p>A beautiful content wrapper for SENAITE that you will love</p>
-
+  
   <div>
     <a href="https://pypi.python.org/pypi/senaite.core.supermodel">
       <img src="https://img.shields.io/pypi/v/senaite.core.supermodel.svg?style=flat-square" alt="pypi-version" />

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </a>
 
   <p>A beautiful content wrapper for SENAITE that you will love</p>
-  
+
   <div>
     <a href="https://pypi.python.org/pypi/senaite.core.supermodel">
       <img src="https://img.shields.io/pypi/v/senaite.core.supermodel.svg?style=flat-square" alt="pypi-version" />
@@ -52,6 +52,6 @@ well to all the metadata columns of the primary catalog of this object:
 
     >>> supermodel.MySchemaField'
     'Value of MySchemaField'
-    
+
 Please read the [full functional doctest](src/senaite/core/supermodel/docs/SUPERMODEL.rst)
 to see the super powers of the `SuperModel` in action.

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 1.0.1 (unreleased)
 ------------------
 
-- no changes yet
+- #2 Allow to pass in a catalog brain or instance to initialize a SuperModel
 
 
 1.0.0 (2018-07-19)

--- a/src/senaite/core/supermodel/docs/SUPERMODEL.rst
+++ b/src/senaite/core/supermodel/docs/SUPERMODEL.rst
@@ -21,8 +21,8 @@ Import it first::
 
     >>> from senaite.core.supermodel import SuperModel
 
-Now we can simply create a new `SuperModel` instance and pass in the Unique ID
-(UID) of a content object.
+Now we can simply create a new `SuperModel` instance by passing in the Unique ID
+(UID) of a content object, a catalog brain or an instance object.
 
 So let's create a client for that::
 
@@ -39,21 +39,46 @@ So let's create a client for that::
      >>> client.getClientID()
      'HH'
 
-Now we can wrap this client into a `SuperModel`::
+Now a `SuperModel` can be instantiated via the UID::
 
     >>> uid = api.get_uid(client)
     >>> supermodel = SuperModel(uid)
 
-This creates a new `SuperModel` instance for us::
+It can be also instantiated via a catalog brain::
+
+    >>> uid_catalog = api.get_tool("uid_catalog")
+    >>> brain = uid_catalog({"UID": uid})[0]
+    >>> supermodel2 = SuperModel(brain)
+
+And it can be instantiated with the content object directly::
+
+    >>> supermodel3 = SuperModel(client)
+
+All of them create new `SuperModel` instances for us::
 
     >>> supermodel
-    <SuperModel:UID(...)> 
+    <SuperModel:UID(...)>
+
+    >>> supermodel2
+    <SuperModel:UID(...)>
+
+    >>> supermodel3
+    <SuperModel:UID(...)>
+
+All of them should be equal::
+
+    >>> supermodel == supermodel2 == supermodel3
+    True
+
+    >>> supermodel.catalog == supermodel2.catalog == supermodel3.catalog
+    True
+
 
 We have now full access to the `Client` schema::
 
     >>> supermodel.Name
     'Happy Hills'
-    
+
     >>> supermodel.ClientID
     'HH'
 
@@ -65,18 +90,17 @@ catalog are lazily fetched::
 
     >>> supermodel.brain
     <Products.ZCatalog.Catalog.mybrains object at ...>
-    
 
 This gives full access to the catalog metadata and content schema::
 
     >>> supermodel.review_state
     'active'
-   
+
 It is also possible to call member functions directly::
 
     >>> supermodel.getPhysicalPath()
     ('', 'plone', 'clients', 'client-1')
-    
+
 
 Not impressed yet?
 ------------------
@@ -179,7 +203,7 @@ therefore possible to traverse schema fields from referenced objects directly::
 
     >>> supermodel.Client.Name
     'Happy Hills'
-    
+
 Furthermore, all fields that were accessed once are internally cached. Another
 fetch would therefore return the cached value instead of getting the attribute
 from the database object::
@@ -189,7 +213,7 @@ from the database object::
 
     >>> supermodel.Client.ClientID
     'HH'
-    
+
     >>> sorted(supermodel.Client.data.items())
     [('ClientID', 'HH'), ('Name', 'Happy Hills')]
 

--- a/src/senaite/core/supermodel/model.py
+++ b/src/senaite/core/supermodel/model.py
@@ -46,6 +46,8 @@ class SuperModel(object):
             return self.init_with_brain(thing)
         if api.is_object(thing):
             return self.init_with_instance(thing)
+        if thing == "0":
+            return self.init_with_instance(api.get_portal())
 
         raise TypeError(
             "Can not initialize a SuperModel with '{}'".format(repr(thing)))

--- a/src/senaite/core/supermodel/model.py
+++ b/src/senaite/core/supermodel/model.py
@@ -247,13 +247,7 @@ class SuperModel(object):
         """
         if not api.is_object(brain_or_object):
             raise TypeError("Invalid object type %r" % brain_or_object)
-        portal_type = api.get_portal_type(brain_or_object)
-        archetype_tool = api.get_tool("archetype_tool")
-        catalogs = archetype_tool.getCatalogsByType(portal_type)
-        if not catalogs:
-            logger.warn("No registered catalog found for portal_type={}"
-                        .format(portal_type))
-            return api.get_tool("uid_catalog")
+        catalogs = api.get_catalogs_for(brain_or_object, default="uid_catalog")
         return catalogs[0]
 
     def get_brain_by_uid(self, uid):

--- a/src/senaite/core/supermodel/model.py
+++ b/src/senaite/core/supermodel/model.py
@@ -35,16 +35,44 @@ class SuperModel(object):
     """
     implements(ISuperModel)
 
-    def __init__(self, uid):
-        logger.debug("SuperModel({})".format(uid))
+    def __init__(self, thing):
 
+        self.data = dict()
+        self.__empty_marker = object
+
+        if api.is_uid(thing):
+            return self.init_with_uid(thing)
+        if api.is_brain(thing):
+            return self.init_with_brain(thing)
+        if api.is_object(thing):
+            return self.init_with_instance(thing)
+
+        raise TypeError(
+            "Can not initialize a SuperModel with '{}'".format(repr(thing)))
+
+    def init_with_uid(self, uid):
+        """Initialize with an UID
+        """
         self._uid = uid
         self._brain = None
         self._catalog = None
         self._instance = None
 
-        self.__empty_marker = object
-        self.data = dict()
+    def init_with_brain(self, brain):
+        """Initialize with a catalog brain
+        """
+        self._uid = api.get_uid(brain)
+        self._brain = brain
+        self._catalog = self.get_catalog_for(brain)
+        self._instance = None
+
+    def init_with_instance(self, instance):
+        """Initialize with an instance object
+        """
+        self._uid = api.get_uid(instance)
+        self._brain = None
+        self._catalog = self.get_catalog_for(instance)
+        self._instance = instance
 
     def __repr__(self):
         return "<{}:UID({})>".format(
@@ -201,10 +229,6 @@ class SuperModel(object):
         if self._brain is None:
             logger.debug("SuperModel::brain: *Fetch catalog brain*")
             self._brain = self.get_brain_by_uid(self.uid)
-            # refetch the brain with the correct catalog
-            results = self.catalog({"UID": self.uid})
-            if results and len(results) == 1:
-                self._brain = results[0]
         return self._brain
 
     @property
@@ -213,25 +237,45 @@ class SuperModel(object):
         """
         if self._catalog is None:
             logger.debug("SuperModel::catalog: *Fetch catalog*")
-            archetype_tool = api.get_tool("archetype_tool")
-            portal_type = self.brain.portal_type
-            catalogs = archetype_tool.getCatalogsByType(portal_type)
-            if catalogs is None:
-                logger.warn("No registered catalog found for portal_type={}"
-                            .format(portal_type))
-                return api.get_tool("uid_catalog")
-            self._catalog = catalogs[0]
+            self._catalog = self.get_catalog_for(self.brain)
         return self._catalog
 
+    def get_catalog_for(self, brain_or_object):
+        """Return the primary catalog for the given brain or object
+        """
+        if not api.is_object(brain_or_object):
+            raise TypeError("Invalid object type %r" % brain_or_object)
+        portal_type = api.get_portal_type(brain_or_object)
+        archetype_tool = api.get_tool("archetype_tool")
+        catalogs = archetype_tool.getCatalogsByType(portal_type)
+        if not catalogs:
+            logger.warn("No registered catalog found for portal_type={}"
+                        .format(portal_type))
+            return api.get_tool("uid_catalog")
+        return catalogs[0]
+
     def get_brain_by_uid(self, uid):
-        """Lookup brain in the UID catalog
+        """Lookup brain from the right catalog
         """
         if uid == "0":
             return api.get_portal()
-        uid_catalog = api.get_tool("uid_catalog")
-        results = uid_catalog({"UID": uid})
+
+        # ensure we have the primary catalog
+        if self._catalog is None:
+            uid_catalog = api.get_tool("uid_catalog")
+            results = uid_catalog({"UID": uid})
+            if len(results) != 1:
+                raise ValueError("No object found for UID '{}'".format(uid))
+            brain = results[0]
+            self._catalog = self.get_catalog_for(brain)
+
+        # Fetch the brain with the primary catalog
+        results = self.catalog({"UID": self.uid})
+        if not results:
+            raise ValueError("No results found for UID '{}'".format(uid))
         if len(results) != 1:
-            raise ValueError("Failed to get brain by UID")
+            raise ValueError("Found more than one object for UID '{}'"
+                             .format(uid))
         return results[0]
 
     @returns_super_model


### PR DESCRIPTION
## Description

This PR implements different initializers to handle UID/catalog brain/content types.

## Current behavior before PR

Only UID was handled

## Desired behavior after PR is merged

UID/catalog brain and instance object can be passed to create a new SuperModel