### PR TITLE
Skip private fields starting with _

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
-1.3.0 (unreleased)
+1.2.1 (unreleased)
 ------------------
 
-- no changes yet
+- #4 Skip private fields starting with `_`
 
 
 1.2.0 (2019-03-30)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "1.3.0"
+version = "1.2.1"
 
 with open("docs/About.rst", "r") as fh:
     long_description = fh.read()

--- a/src/senaite/core/supermodel/model.py
+++ b/src/senaite/core/supermodel/model.py
@@ -126,7 +126,8 @@ class SuperModel(object):
             yield k
 
     def keys(self):
-        return self.instance.Schema().keys()
+        fields = self.instance.Schema().keys()
+        return filter(lambda f: not f.startswith("_"), fields)
 
     def iteritems(self):
         for k in self:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this PR private schema fields starting with `_` are no longer retrieved when calling `to_dict`.

## Current behavior before PR

The `keys` method retrieved all schema fields

## Desired behavior after PR is merged

The `keys` method filters out schema fields starting with `_`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
