### PR TITLE
Fix UID->SuperModel conversion of UIDReferenceFields

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.1 (unreleased)
 ------------------
 
+- #5 Fix UID->SuperModel conversion of UIDReferenceFields
 - #4 Skip private fields starting with `_`
 
 

--- a/src/senaite/core/supermodel/model.py
+++ b/src/senaite/core/supermodel/model.py
@@ -294,7 +294,7 @@ class SuperModel(object):
         """Wraps an object into a Super Model
         """
         if api.is_uid(thing):
-            return self.get_brain_by_uid(thing)
+            return thing
         if not api.is_object(thing):
             raise TypeError("Expected a portal object, got '{}'"
                             .format(type(thing)))

--- a/src/senaite/core/supermodel/model.py
+++ b/src/senaite/core/supermodel/model.py
@@ -281,7 +281,7 @@ class SuperModel(object):
             self._catalog = self.get_catalog_for(brain)
 
         # Fetch the brain with the primary catalog
-        results = self.catalog({"UID": self.uid})
+        results = self.catalog({"UID": uid})
         if not results:
             raise ValueError("No results found for UID '{}'".format(uid))
         if len(results) != 1:

--- a/src/senaite/core/supermodel/model.py
+++ b/src/senaite/core/supermodel/model.py
@@ -294,7 +294,7 @@ class SuperModel(object):
         """Wraps an object into a Super Model
         """
         if api.is_uid(thing):
-            return thing
+            return SuperModel(thing)
         if not api.is_object(thing):
             raise TypeError("Expected a portal object, got '{}'"
                             .format(type(thing)))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the UID->SuperModel conversion of UIDReference fields.

## Current behavior before PR

SuperModels generated from UIDReferenceFields referenced the instance itself

## Desired behavior after PR is merged

SuperModels generated from UIDReferenceFields reference the target objects

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
