### PR TITLE
Fix traceback when initializing a supermodel with a catalog brain

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.1 (unreleased)
 ------------------
 
+- #7 Fix traceback when initializing a supermodel with a catalog brain
 - #6 Added Destructor and further improvements
 - #5 Fix UID->SuperModel conversion of UIDReferenceFields
 - #4 Skip private fields starting with `_`

--- a/src/senaite/core/supermodel/model.py
+++ b/src/senaite/core/supermodel/model.py
@@ -54,7 +54,7 @@ class SuperModel(object):
     def __init__(self, thing):
 
         # Type based initializers
-        if thing == "0":
+        if isinstance(thing, basestring) and thing == "0":
             self.init_with_instance(api.get_portal())
         elif api.is_uid(thing):
             self.init_with_uid(thing)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is related to https://github.com/senaite/senaite.core/issues/1354

## Current behavior before PR

Traceback occured when a supermodel was initialized with a catalog brain:
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.widgets.referencewidget, line 297, in __call__
  Module bika.lims.browser.widgets.referencewidget, line 271, in to_data_rows
  Module bika.lims.browser.widgets.referencewidget, line 271, in <lambda>
  Module bika.lims.browser.widgets.referencewidget, line 246, in get_data_record
  Module senaite.core.supermodel.model, line 59, in __init__
  Module senaite.core.supermodel.model, line 59, in __init__
  Module bdb, line 49, in trace_dispatch
  Module bdb, line 67, in dispatch_line
  Module pdb, line 158, in user_line
  Module pdb, line 227, in interaction
  Module cmd, line 130, in cmdloop
  Module pyrepl.readline, line 199, in raw_input
  Module pyrepl.reader, line 597, in readline
  Module pyrepl.historical_reader, line 240, in prepare
  Module pyrepl.reader, line 480, in prepare
  Module pyrepl.unix_console, line 359, in prepare
  Module pyrepl.fancy_termios, line 34, in tcgetattr
TypeError: mybrains.__cmp__(x,y) requires y to be a 'mybrains', not a 'str'
```

## Desired behavior after PR is merged

No traceback occurs when a supermodel is initialized with a catalog brain

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
