### PR TITLE
Do not process "0" values to Portal-SuperModels

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.1 (unreleased)
 ------------------
 
+- #8 Do not process "0" values to Portal-SuperModels
 - #7 Fix traceback when initializing a supermodel with a catalog brain
 - #6 Added Destructor and further improvements
 - #5 Fix UID->SuperModel conversion of UIDReferenceFields

--- a/src/senaite/core/supermodel/model.py
+++ b/src/senaite/core/supermodel/model.py
@@ -227,6 +227,10 @@ class SuperModel(object):
         """
         # UID -> SuperModel
         if api.is_uid(value):
+            # Do not process "0" as the portal object
+            # -> Side effect in specifications when the value is "0"
+            if value == "0":
+                return "0"
             return self.to_super_model(value)
         # Content -> SuperModel
         elif api.is_object(value):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue where "0" specifications were converted to a wrapped Portal `SuperModel` when accessing e.g. `model.ResultRange`

## Current behavior before PR

"0" Values are automatically converted to a Portal `SuperModel` 

## Desired behavior after PR is merged

"0" Values are not automatically converted to a Portal `SuperModel` 


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
