### PR TITLE
Do not consider Auditlog catalog as primary catalog 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.0.1 (unreleased)
 ------------------
 
+- #11 Do not consider Auditlog catalog as primary catalog
 
 
 2.0.0 (2021-07-26)

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -34,7 +34,7 @@ from zope.interface import implements
 
 _marker = object()
 
-IGNORE_CATALOGS = [AUDITLOG_CATALOG, "portal_catalog"]
+IGNORE_CATALOGS = [AUDITLOG_CATALOG]
 
 
 class SuperModel(object):

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -34,6 +34,8 @@ from zope.interface import implements
 
 _marker = object()
 
+IGNORE_CATALOGS = [AUDITLOG_CATALOG, "portal_catalog"]
+
 
 class SuperModel(object):
     """Generic wrapper for content objects
@@ -304,7 +306,7 @@ class SuperModel(object):
         catalogs = api.get_catalogs_for(brain_or_object, default=default)
 
         # filter out auditlog catalog
-        catalogs = filter(lambda cat: cat.id != AUDITLOG_CATALOG, catalogs)
+        catalogs = filter(lambda cat: cat.id not in IGNORE_CATALOGS, catalogs)
         if not catalogs:
             return api.get_tool(default)
         return catalogs[0]

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -30,6 +30,7 @@ from senaite.app.supermodel import logger
 from senaite.app.supermodel.decorators import returns_super_model
 from senaite.app.supermodel.interfaces import ISuperModel
 from senaite.core.catalog import AUDITLOG_CATALOG
+from senaite.core.interfaces import ISenaiteCatalog
 from zope.interface import implements
 
 _marker = object()
@@ -307,8 +308,16 @@ class SuperModel(object):
 
         # filter out auditlog catalog
         catalogs = filter(lambda cat: cat.id not in IGNORE_CATALOGS, catalogs)
+
+        # return default catalog when empty
         if not catalogs:
             return api.get_tool(default)
+
+        # prefer senaite catalogs over any other ones
+        for catalog in catalogs:
+            if ISenaiteCatalog.providedBy(catalog):
+                return catalog
+
         return catalogs[0]
 
     def get_brain_by_uid(self, uid):

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -29,6 +29,7 @@ from Products.ZCatalog.Lazy import LazyMap
 from senaite.app.supermodel import logger
 from senaite.app.supermodel.decorators import returns_super_model
 from senaite.app.supermodel.interfaces import ISuperModel
+from senaite.core.catalog import AUDITLOG_CATALOG
 from zope.interface import implements
 
 _marker = object()
@@ -294,13 +295,18 @@ class SuperModel(object):
             self._catalog = self.get_catalog_for(self.brain)
         return self._catalog
 
-    def get_catalog_for(self, brain_or_object):
+    def get_catalog_for(self, brain_or_object, default="uid_catalog"):
         """Return the primary catalog for the given brain or object
         """
         if not api.is_object(brain_or_object):
             raise TypeError("Invalid object type %r" % brain_or_object)
-        catalogs = api.get_catalogs_for(brain_or_object, default="uid_catalog")
 
+        catalogs = api.get_catalogs_for(brain_or_object, default=default)
+
+        # filter out auditlog catalog
+        catalogs = filter(lambda cat: cat.id != AUDITLOG_CATALOG, catalogs)
+        if not catalogs:
+            return api.get_tool(default)
         return catalogs[0]
 
     def get_brain_by_uid(self, uid):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

After the migration of the catalogs in https://github.com/senaite/senaite.core/pull/1872 the Auditlog catalogs might appear first in the `archetype_tool` for some contents, e.g. `AnalysisRequest`.

When the auditlog catalog was cleared, objects wrapped in a `SuperModel` could not be found.

The following log message appeared:

`Could not fetch report model for UID=5878c864d51e4b009a12bcd104593b2d`

## Current behavior before PR

The code used `senaite_catalog_auditlog` as primary catalog

## Desired behavior after PR is merged

The code filters out `senaite_catalog_auditlog` for the primary catalog and falls back to `uid_catalog` when no catalog was found.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
