### PR TITLE
Fix infinite recursion for catalog values containing `Missing.Value`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.2.0 (unreleased)
 ------------------
 
-- no changes yet
+- #12 Fix infinite recursion for catalog values containing `Missing.Value`
 
 
 2.1.0 (2022-01-05)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an infinite recursion error for catalog values containing `Missing.Value`:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.autoform.view, line 42, in __call__
  Module plone.autoform.view, line 33, in render
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 67ee160c71aee01eacd9e31d654b71f2, line 517, in render
  Module d36efa475dac19ca61f4fc92e97130ea, line 1449, in render_master
  Module d36efa475dac19ca61f4fc92e97130ea, line 407, in render_content
  Module 67ee160c71aee01eacd9e31d654b71f2, line 502, in __fill_content_core
  Module 67ee160c71aee01eacd9e31d654b71f2, line 151, in render_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module zope.browserpage.simpleviewclass, line 41, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 81, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module dffe827008b257b42ae2014b18b638af, line 586, in render
  Module dffe827008b257b42ae2014b18b638af, line 456, in render_widget_wrapper
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module z3c.form.widget, line 154, in render
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module f4a0ea290e246313672b7691e8950906, line 152, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (view.render_reference(uid))
  Module <string>, line 1, in <module>
  Module senaite.core.z3cform.widgets.uidreference, line 212, in render_reference
  Module senaite.core.z3cform.widgets.uidreference, line 203, in get_obj_info
  Module senaite.app.supermodel.model, line 407, in to_dict
  Module senaite.app.supermodel.model, line 163, in iteritems
  Module senaite.app.supermodel.model, line 136, in __getitem__
  Module senaite.app.supermodel.model, line 222, in get
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
  Module senaite.app.supermodel.model, line 256, in process_value
RuntimeError: maximum recursion depth exceeded while calling a Python object
```

## Current behavior before PR

Maximum recursion depth exceeded error raised in `process_value` when the value was `Missing.Value` and the `to_dict` method was called.

## Desired behavior after PR is merged

Catalog values containing `Missing.Value` are processed to `None`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
