### PR TITLE
Remove dependency to Products.TextIndexNG3 (test layer)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
-- no changes yet
+- #13 Remove dependency to Products.TextIndexNG3 (test layer)
 
 
 2.2.0 (2022-06-10)

--- a/src/senaite/app/supermodel/tests/base.py
+++ b/src/senaite/app/supermodel/tests/base.py
@@ -37,7 +37,6 @@ class SimpleTestLayer(PloneSandboxLayer):
     def setUpZope(self, app, configurationContext):
         super(SimpleTestLayer, self).setUpZope(app, configurationContext)
 
-        import Products.TextIndexNG3
         import bika.lims
         import senaite.core
         import senaite.app.listing
@@ -45,7 +44,6 @@ class SimpleTestLayer(PloneSandboxLayer):
         import senaite.app.spotlight
 
         # Load ZCML
-        self.loadZCML(package=Products.TextIndexNG3)
         self.loadZCML(package=bika.lims)
         self.loadZCML(package=senaite.core)
         self.loadZCML(package=senaite.app.listing)
@@ -53,7 +51,6 @@ class SimpleTestLayer(PloneSandboxLayer):
         self.loadZCML(package=senaite.app.spotlight)
 
         # Install product and call its initialize() function
-        zope.installProduct(app, "Products.TextIndexNG3")
         zope.installProduct(app, "bika.lims")
         zope.installProduct(app, "senaite.core")
         zope.installProduct(app, "senaite.app.listing")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the `Products.TextIndexNG3` dependency on the test layer because it is no longer a SENAITE dependency as per https://github.com/senaite/senaite.core/pull/2011 and https://github.com/senaite/senaite.core/pull/2014


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
