### PR TITLE
Ignore fields from extensible metadata schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
+- #14 Ignore fields from extensible metadata schema
 - #13 Remove dependency to Products.TextIndexNG3 (test layer)
 
 

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -39,6 +39,19 @@ _marker = object()
 
 IGNORE_CATALOGS = [AUDITLOG_CATALOG]
 
+# Ingore irrelevant fields coming from Archetypes Extensible Metadata
+# -> if required, these fields have to be fetched from the instance itself
+IGNORE_SCHEMA_FIELDS = [
+    "allowDiscussion",  # avoid depreciation message when accessing the field
+    "contributors",
+    "creators",
+    "expirationDate",
+    "language",
+    "location",
+    "rights",
+    "subject",
+]
+
 
 class SuperModel(object):
     """Generic wrapper for content objects
@@ -157,7 +170,14 @@ class SuperModel(object):
 
     def keys(self):
         fields = api.get_fields(self.instance).keys()
-        return filter(lambda f: not f.startswith("_"), fields)
+        keys = []
+        for field in fields:
+            if field.startswith("_"):
+                continue
+            if field in IGNORE_SCHEMA_FIELDS:
+                continue
+            keys.append(field)
+        return keys
 
     def iteritems(self):
         for k in self:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR filters out some irrelevant fields from Archetypes extensible metadata, to improve performance and avoid depreciation messages
 
## Current behavior before PR

Depreciation message regarding Discussion field on sample create

## Desired behavior after PR is merged

No more depreciation message shown when creating samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
