### PR TITLE
Do not fail when no catalog brain was found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
-- no changes yet
+- #17 Do not fail when no catalog brain was found
 
 
 2.4.0 (2023-03-10)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR avoids a `ValueError` if no catalog brain was found

## Current behavior before PR

An uncatched `ValueError` was raised if no catalog brain was found, e.g. which might be the case during the creation process if the object is temporary and not catalogued.

## Desired behavior after PR is merged

No value error is raised if no catalog brain was found.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
