### PR TITLE
Avoid brain lookup for temporary objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #18 Avoid brain lookup for temporary objects
 - #17 Do not fail when no catalog brain was found
 
 

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -96,6 +96,7 @@ class SuperModel(object):
         self._catalog = None
         self._instance = None
         self._uid = uid
+        self._temporary = None
 
     def init_with_brain(self, brain):
         """Initialize with a catalog brain
@@ -104,6 +105,7 @@ class SuperModel(object):
         self._catalog = self.get_catalog_for(brain)
         self._instance = None
         self._uid = api.get_uid(brain)
+        self._temporary = None
 
     def init_with_instance(self, instance):
         """Initialize with an instance object
@@ -112,6 +114,16 @@ class SuperModel(object):
         self._catalog = self.get_catalog_for(instance)
         self._instance = instance
         self._uid = api.get_uid(instance)
+        self._temporary = api.is_temporary(instance)
+
+    def is_temporary(self, instance):
+        """Check if the object is temporary / in initialization
+
+        :returns: True if the passed in object is temporary, otherwise False
+        """
+        if self._temporary is None:
+            self._temporary = api.is_temporary(instance)
+        return self._temporary
 
     def __del__(self):
         """Destructor
@@ -235,7 +247,7 @@ class SuperModel(object):
             accessor = field.getAccessor(self.instance)
             accessor_name = accessor.__name__
 
-            if not api.is_temporary(self.instance):
+            if self.is_temporary(self.instance) is False:
                 # Metadata lookup by accessor name
                 value = getattr(self.brain, accessor_name, _marker)
 

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -352,7 +352,7 @@ class SuperModel(object):
         """Return the primary catalog for the given brain or object
         """
         if not api.is_object(brain_or_object):
-            raise TypeError("Invalid object type %r" % brain_or_object)
+            return default
 
         catalogs = api.get_catalogs_for(brain_or_object, default=default)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR avoids multiple brain lookups during the initialization phase of e.g. samples.

## Current behavior before PR

Brain lookup is done multiple times, although the object is not yet indexed

## Desired behavior after PR is merged

Brain lookup is skipped if object is temporary or at most done only once.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
