### PR TITLE
Prioritize getters instead of fieldnames when getting values from instance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.6.0 (unreleased)
 ------------------
 
+- #19 Process values returned from instance except when a function
 - no changes yet
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.6.0 (unreleased)
 ------------------
 
-- #19 Support for Dexterity's non-CamelCase fieldnames
+- #19 Prioritize getters instead of fieldnames on value retrieval from instance
 - no changes yet
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,6 @@
 ------------------
 
 - #19 Prioritize getters instead of fieldnames on value retrieval from instance
-- no changes yet
 
 
 2.5.0 (2024-01-03)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.6.0 (unreleased)
 ------------------
 
-- #19 Process values returned from instance except when a function
+- #19 Support for Dexterity's non-CamelCase fieldnames
 - no changes yet
 
 

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -217,12 +217,6 @@ class SuperModel(object):
         if field:
             return field
 
-        # DX fields are not CamelCase but snake_case
-        name = "".join("_" + c.lower() if c.isupper() else c for c in name)
-        field = fields.get(name)
-        if field:
-            return field
-
         return default
 
     def get_field_value(self, name, default=None):

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -230,7 +230,8 @@ class SuperModel(object):
                 instance = self.instance
                 instance_value = getattr(instance, name, _marker)
                 if instance_value is not _marker:
-                    return instance_value
+                    # return the value processed, but only if not a function
+                    return self.process_value(instance_value, safe_call=False)
 
                 # check if the brain contains this attribute
                 brain = self.brain
@@ -265,7 +266,7 @@ class SuperModel(object):
 
         return value
 
-    def process_value(self, value):
+    def process_value(self, value, safe_call=True):
         """Process publication value
         """
         # UID -> SuperModel
@@ -293,7 +294,7 @@ class SuperModel(object):
         elif isinstance(value, (dict)):
             return {k: self.process_value(v) for k, v in value.iteritems()}
         # Process function
-        elif safe_callable(value):
+        elif safe_call and safe_callable(value):
             return self.process_value(value())
         # Always return the unprocessed value last
         return value

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -231,7 +231,11 @@ class SuperModel(object):
                 instance_value = getattr(instance, name, _marker)
                 if instance_value is not _marker:
                     # return the value processed, but only if not a function
-                    return self.process_value(instance_value, safe_call=False)
+                    value = self.process_value(instance_value, safe_call=False)
+                    if value != instance_value:
+                        # Store value in the internal data dict
+                        self.data[name] = value
+                    return value
 
                 # check if the brain contains this attribute
                 brain = self.brain


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a bug introduced with https://github.com/senaite/senaite.core/pull/2471 because of the use of properties (e.g. [`Manager`](https://github.com/senaite/senaite.core/pull/2471/files#diff-decbf6a6278fe8897db9f1655ea851e15912b7304548aa74e331c97467336832R158) to let supermodel and impress overcome the fact that with dexterity, name fields are in lower case. However, when calling the property with supermodel, the system returns the object directly, instead of the function:

```python
> /home/senaite/zinstance/src/senaite.app.supermodel/src/senaite/app/supermodel/model.py(232)
 214         def get(self, name, default=None):                                                                                       
 215             # Internal lookup in the data dict                                                                                   
 216             value = self.data.get(name, _marker)                                                                                 
 217                                                                                                                                  
 218             # Return the value immediately                                                                                       
 219             if value is not _marker:                                                                                             
 220                 return self.data[name]                                                                                           
 221                                                                                                                                  
 222             # Field lookup on the instance                                                                                       
 223             field = self.get_field(name)                                                                                         
 224                                                                                                                                  
 225             if field is None:                                                                                                    
 226                 # expose non-private members of the instance/brain to have access                                                
 227                 # to e.g. self.absolute_url (function object) or self.review_state                                               
 228                 if not name.startswith("_") or not name.startswith("__"):                                                        
 229                     # check if the instance contains this attribute                                                              
 230                     instance = self.instance                                                                                     
 231                     instance_value = getattr(instance, name, _marker)                                                            
 232  ->                 if instance_value is not _marker:                                                                            
 233                         return instance_value    
(Pdb++) instance
<Department at /senaite/setup/departments/department-1>
(Pdb++) getattr(instance, "Manager")
<LabContact at /senaite/bika_setup/bika_labcontacts/labcontact-1 used for /senaite/setup/departments/department-1>
(Pdb++) getattr(instance, "getManager")
<bound method Department.getManager of <Department at /senaite/setup/departments/department-1>>

```

When `Department` object was an `Archetype`, `self.get_field(name)` at line 223 would return the accessor to the field `Manager`, so the output of `process_value` would be returned instead.

Since `Departmen` is no longer `AT`, but a `DX`, there is no field `Manager` and calling `model.Manager` returns the object instead of the expected `SuperModel`, which leads to the following traceback in `senaite.impress`:

```
Error: Fullname

    Expression: "manager/Fullname"
    Filename: ... /senaite/impress/analysisrequest/templates/signatures.pt
    Location: (line 19: col 35)
    Source:
    ^^^^^^^^^^^^^^^^
    Expression: "python:view.render_signatures(context, **options)"
    Filename: ... ss/src/senaite/impress/templates/reports/MultiDefault.pt
    Location: (line 37: col 28)
    Source: ... ucture python:view.render_signatures(context, **options)" />
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Therefore, this pull request ensures that functions are returned as-is, while non-functions are processed as expected.

Linked issue: https://github.com/senaite/senaite.impress/issues/148

## Current behavior before PR

Traceback when trying to publish a results report because the system expects a Supermodel to be returned by [`model.Manager` at `senaite.impress.analysisrequest.model.managers`](https://github.com/senaite/senaite.impress/blob/78175140b901a551b3af714dd78ddfaa07d0f6da/src/senaite/impress/analysisrequest/model.py#L236)

## Desired behavior after PR is merged

No traceback. Report is published correctly


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
