### PR TITLE
Special handling of title and description attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.6.0 (unreleased)
 ------------------
 
+- #20 Special handling of title and description attributes
 - #19 Prioritize getters instead of fieldnames on value retrieval from instance
 
 

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -222,6 +222,10 @@ class SuperModel(object):
     def get_field_value(self, name, default=None):
         """Returns the value for the given name and current instance
         """
+        # Special "fields" that are widely accessed in lowercase
+        if name in ["title", "description"]:
+            return getattr(self.instance, name)
+
         # always give priority to getters regardless of type
         accessor_name = "get{}".format(name)
         accessor = getattr(self.instance, accessor_name, _marker)

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -222,9 +222,11 @@ class SuperModel(object):
     def get_field_value(self, name, default=None):
         """Returns the value for the given name and current instance
         """
-        # Special "fields" that are widely accessed in lowercase
-        if name in ["title", "description"]:
-            return getattr(self.instance, name)
+        # These are special "fields" that are widely accessed in lowercase,
+        # but we always need to rely on the capitalized function
+        if name.lower() in ["title", "description"]:
+            func = getattr(self.instance, name.capitalize(), None)
+            return func() if func else ""
 
         # always give priority to getters regardless of type
         accessor_name = "get{}".format(name)

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -226,7 +226,7 @@ class SuperModel(object):
         # but we always need to rely on the capitalized function
         if name.lower() in ["title", "description"]:
             func = getattr(self.instance, name.capitalize(), None)
-            return func() if func else ""
+            return func() if func else default
 
         # always give priority to getters regardless of type
         accessor_name = "get{}".format(name)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`title` and `description` are kind-of special fields that are defined in lowercase in AT framework. However, the framework does not create normal `getters` as the rest of fields, but simply relies on `Title()` and `Description()`. Same behavior has been kept for dexterity types.

This Pull Request handles this particularity when accessing them, cause the following expression is commonly used `supermodel.title` . Without this special handling, the system falls-back to the object id, that is not correct in most cases.


## Current behavior before PR

System returns the value for `id` when `supermodel.title` is used

## Desired behavior after PR is merged

System returns the value for `title` when `supermodel.title` is used

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
