### PR TITLE
Fix error when using Title() or Description() on DX-based types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.6.0 (unreleased)
 ------------------
 
+- #21 Fix error when using Title() or Description() on DX-based types
 - #20 Special handling of title and description attributes
 - #19 Prioritize getters instead of fieldnames on value retrieval from instance
 

--- a/src/senaite/app/supermodel/docs/SUPERMODEL.rst
+++ b/src/senaite/app/supermodel/docs/SUPERMODEL.rst
@@ -65,7 +65,8 @@ Setup the testing environment:
 
     >>> portal = self.portal
     >>> request = self.request
-    >>> setup = portal.bika_setup
+    >>> bika_setup = portal.bika_setup
+    >>> setup = portal.setup
     >>> date_now = DateTime().strftime("%Y-%m-%d")
     >>> date_future = (DateTime() + 5).strftime("%Y-%m-%d")
     >>> setRoles(portal, TEST_USER_ID, ['LabManager', ])
@@ -77,13 +78,13 @@ LIMS Setup
 
 Setup the Lab for testing:
 
-    >>> setup.setSelfVerificationEnabled(True)
-    >>> analysisservices = setup.bika_analysisservices
+    >>> bika_setup.setSelfVerificationEnabled(True)
+    >>> analysisservices = bika_setup.bika_analysisservices
     >>> client = api.create(portal.clients, "Client", title="Happy Hills", ClientID="HH")
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
-    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
-    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="Water")
+    >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.departments, "Department", title="Chemistry", manager=labcontact)
+    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="Water", Prefix="Water")
 
 
 Content Setup

--- a/src/senaite/app/supermodel/docs/dx_vs_at.rst
+++ b/src/senaite/app/supermodel/docs/dx_vs_at.rst
@@ -52,8 +52,10 @@ that for a DX type, SuperModel will try first to rely on a getter.
 
 Create one Archetype and one Dexterity objects:
 
-    >>> at = api.create(portal.clients, "Client", title="Archetype object", ClientID="AT")
-    >>> dx = api.create(setup.departments, "Department", title="Dexterity object", department_id="DX")
+    >>> at = api.create(portal.clients, "Client", title="Archetype object",
+    ...                 description="My AT description", ClientID="AT")
+    >>> dx = api.create(setup.departments, "Department", title="Dexterity object",
+    ...                 description="My DX description", department_id="DX")
 
     >>> api.is_at_content(at)
     True
@@ -71,8 +73,14 @@ We expect same behavior with `title` and `description` attributes:
     >>> at_sm.title
     'Archetype object'
 
+    >>> at_sm.description
+    'My AT description'
+
     >>> dx_sm.title
     'Dexterity object'
+
+    >>> dx_sm.description
+    'My DX description'
 
 And same behavior with `Title` and `Description` getters:
 
@@ -87,6 +95,18 @@ And same behavior with `Title` and `Description` getters:
 
     >>> dx_sm.Title
     <bound method Department.Title of <Department at /plone/setup/departments/department-1>>
+
+    >>> at_sm.Description()
+    'My AT description'
+
+    >>> at_sm.Description
+    <bound method Client.Description of <Client at /plone/clients/client-1>>
+
+    >>> dx_sm.Description()
+    'My DX description'
+
+    >>> dx_sm.Description
+    <bound method Department.Description of <Department at /plone/setup/departments/department-1>>
 
 While we expect SuperModel to behave the same with fields:
 
@@ -113,3 +133,18 @@ is no field set with the given name:
 
     >>> dx_sm.DepartmentID
     'DX'
+
+Same principles apply when using brains:
+
+    >>> brain = api.get_brain_by_uid(dx.UID())
+    >>> brain_sm = SuperModel(brain)
+
+    >>> brain_sm.title
+    'Dexterity object'
+
+    >>> brain_sm.Title()
+    'Dexterity object'
+
+    >>> brain_sm.Title
+    <bound method Department.Title of <Department at /plone/setup/departments/department-1>>
+

--- a/src/senaite/app/supermodel/docs/dx_vs_at.rst
+++ b/src/senaite/app/supermodel/docs/dx_vs_at.rst
@@ -83,6 +83,20 @@ We expect same behavior with `title` and `description` attributes:
     >>> dx_sm.description
     'My DX description'
 
+And for `id` as well:
+
+    >>> at_sm.id
+    'client-1'
+
+    >>> at_sm.getId()
+    'client-1'
+
+    >>> dx_sm.id
+    'department-1'
+
+    >>> dx_sm.getId()
+    'department-1'
+
 And same behavior with `Title` and `Description` getters:
 
     >>> at_sm.Title()
@@ -140,6 +154,12 @@ Same principles apply when using brains:
     >>> cat = api.get_tool(SETUP_CATALOG)
     >>> brain = cat(UID=dx.UID())[0]
     >>> brain_sm = SuperModel(brain)
+
+    >>> brain_sm.id
+    'department-1'
+
+    >>> brain_sm.getId()
+    'department-1'
 
     >>> brain_sm.title
     'Dexterity object'

--- a/src/senaite/app/supermodel/docs/dx_vs_at.rst
+++ b/src/senaite/app/supermodel/docs/dx_vs_at.rst
@@ -148,3 +148,23 @@ Same principles apply when using brains:
     >>> brain_sm.Title
     <bound method Department.Title of <Department at /plone/setup/departments/department-1>>
 
+    >>> brain_sm.description
+    'My DX description'
+
+    >>> brain_sm.Description()
+    'My DX description'
+
+    >>> brain_sm.Description
+    <bound method Department.Description of <Department at /plone/setup/departments/department-1>>
+
+    >>> brain_sm.department_id
+    'DX'
+
+    >>> brain_sm.getDepartmentID
+    <bound method Department.getDepartmentID of <Department at /plone/setup/departments/department-1>>
+
+    >>> brain_sm.getDepartmentID()
+    'DX'
+
+    >>> brain_sm.DepartmentID
+    'DX'

--- a/src/senaite/app/supermodel/docs/dx_vs_at.rst
+++ b/src/senaite/app/supermodel/docs/dx_vs_at.rst
@@ -1,0 +1,115 @@
+Supermodel with Dexterity and Archetypes
+========================================
+
+Supermodel provides same behavior regardless of the underlying framework of
+the content types, this being Archetypes or Dexterity.
+
+Running this test from the buildout directory:
+
+    bin/test test_doctests -t dx_vs_at
+
+Test Setup
+----------
+
+    >>> from bika.lims import api
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import setRoles
+    >>> from senaite.app.supermodel.model import SuperModel
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.setup
+    >>> bika_setup = portal.bika_setup
+
+Test special attrs title and description
+----------------------------------------
+
+CamelCase is the convention used for field names in AT content types. The
+system automatically generates the accessors for them. As an example, for a
+field `CommercialName`, the system generates automagically the accessors
+`getCommercialName()` and `setCommercialName()`. This is true for AT types
+except for the fields `title` and `description`, that are declared in lowercase
+and for which the framework automatically generates the accessors `Title()`
+and `Description()`.
+
+On the other hand, snake case is the convention used for field names in DX
+content types. However, we use explicit accessors that follow CamelCase
+convention to get them. Therefore, if the field name is `commercial_name` we
+expect the accessors `getCommercialName()` and `setCommercialName()`. As
+for AT types, field `title` and `description` are special and are commonly
+accessed with the auto-generated getters `Title()` and `Description()`.
+
+The rule of thumb is that **supermodel must behave like an instance**. This
+means, that `model.Title` or `model.Description` must return the methods
+instead of the value, while `model.title` and `model.description` should return
+the values instead of the functions.
+
+Likewise, `model.getCommercialName` must return the method and `CommercialName`
+the value, regardless of the underlying type of the object. Note therefore,
+that for a DX type, SuperModel will try first to rely on a getter.
+
+Create one Archetype and one Dexterity objects:
+
+    >>> at = api.create(portal.clients, "Client", title="Archetype object", ClientID="AT")
+    >>> dx = api.create(setup.departments, "Department", title="Dexterity object", department_id="DX")
+
+    >>> api.is_at_content(at)
+    True
+
+    >>> api.is_dexterity_content(dx)
+    True
+
+And their SuperModel counterparts:
+
+    >>> at_sm = SuperModel(at)
+    >>> dx_sm = SuperModel(dx)
+
+We expect same behavior with `title` and `description` attributes:
+
+    >>> at_sm.title
+    'Archetype object'
+
+    >>> dx_sm.title
+    'Dexterity object'
+
+And same behavior with `Title` and `Description` getters:
+
+    >>> at_sm.Title()
+    'Archetype object'
+
+    >>> at_sm.Title
+    <bound method Client.Title of <Client at /plone/clients/client-1>>
+
+    >>> dx_sm.Title()
+    'Dexterity object'
+
+    >>> dx_sm.Title
+    <bound method Department.Title of <Department at /plone/setup/departments/department-1>>
+
+While we expect SuperModel to behave the same with fields:
+
+    >>> at_sm.ClientID
+    'AT'
+
+    >>> at_sm.getClientID
+    <bound method Client.getClientID of <Client at /plone/clients/client-1>>
+
+    >>> at_sm.getClientID()
+    'AT'
+
+    >>> dx_sm.department_id
+    'DX'
+
+    >>> dx_sm.getDepartmentID
+    <bound method Department.getDepartmentID of <Department at /plone/setup/departments/department-1>>
+
+    >>> dx_sm.getDepartmentID()
+    'DX'
+
+However, note that for dexterity types, system will rely on a getter if there
+is no field set with the given name:
+
+    >>> dx_sm.DepartmentID
+    'DX'

--- a/src/senaite/app/supermodel/docs/dx_vs_at.rst
+++ b/src/senaite/app/supermodel/docs/dx_vs_at.rst
@@ -15,6 +15,7 @@ Test Setup
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import setRoles
     >>> from senaite.app.supermodel.model import SuperModel
+    >>> from senaite.core.catalog import SETUP_CATALOG
 
 Variables:
 
@@ -136,7 +137,8 @@ is no field set with the given name:
 
 Same principles apply when using brains:
 
-    >>> brain = api.get_brain_by_uid(dx.UID())
+    >>> cat = api.get_tool(SETUP_CATALOG)
+    >>> brain = cat(UID=dx.UID())[0]
     >>> brain_sm = SuperModel(brain)
 
     >>> brain_sm.title

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -224,7 +224,7 @@ class SuperModel(object):
         """
         # These are special "fields" that are widely accessed in lowercase,
         # but we always need to rely on the capitalized function
-        if name.lower() in ["title", "description"]:
+        if name in ["title", "description"]:
             func = getattr(self.instance, name.capitalize(), None)
             return func() if func else default
 

--- a/src/senaite/app/supermodel/tests/test_doctests.py
+++ b/src/senaite/app/supermodel/tests/test_doctests.py
@@ -18,22 +18,31 @@
 # Copyright 2018-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from os.path import join
+
 import doctest
-
 import unittest2 as unittest
-
+from pkg_resources import resource_listdir
 from Testing import ZopeTestCase as ztc
 
 from .base import SimpleTestCase
 
+product = "senaite.app.supermodel"
+files = resource_listdir(product, "docs")
+rst_filenames = [fn for fn in files if fn.endswith(".rst")]
+doctests = [join("../docs", filename) for filename in rst_filenames]
+
+flags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF
+
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([
-        ztc.ZopeDocFileSuite(
-            '../docs/SUPERMODEL.rst',
-            test_class=SimpleTestCase,
-            optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE,
-        ),
-    ])
+    for doctestfile in doctests:
+        suite.addTests([
+            ztc.ZopeDocFileSuite(
+                doctestfile,
+                test_class=SimpleTestCase,
+                optionflags=flags
+            )
+        ])
     return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an error that occurs when using the functions `Title()` and `Description()` on DX-based supermodels

## Current behavior before PR

`supermodel.Title()` gives error

## Desired behavior after PR is merged

`supermodel.Title()` returns the value of `title`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
