### PR TITLE
Rely on getRaw for the retrieval of UIDs from reference-like fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.6.0 (unreleased)
 ------------------
 
+- #23 Rely on getRaw for the retrieval of UIDs from reference-like fields
 - #21 Fix error when using Title() or Description() on DX-based types
 - #20 Special handling of title and description attributes
 - #19 Prioritize getters instead of fieldnames on value retrieval from instance


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull request makes the supermodel machinery to prevent querying the database for the extraction of objects from reference-like fields. With this pull request the system simply relies on `getRaw` to extract directly the UIDs, to create a `SuperModel` later.

## Current behavior before PR

System always triggers a query for the retrieval of objects from reference-like fields

## Desired behavior after PR is merged

System relies on `getRaw` for the retrieval of UIDs from reference-like fields

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
