### PR TITLE
Do not take IARAnalysesField as a uidreference-like field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.6.0 (unreleased)
 ------------------
 
+- #24 Do not take IARAnalysesField as a uidreference-like field
 - #23 Rely on getRaw for the retrieval of UIDs from reference-like fields
 - #21 Fix error when using Title() or Description() on DX-based types
 - #20 Special handling of title and description attributes

--- a/src/senaite/app/supermodel/model.py
+++ b/src/senaite/app/supermodel/model.py
@@ -24,7 +24,6 @@ import six
 
 import Missing
 from bika.lims import api
-from bika.lims.interfaces import IARAnalysesField
 from bika.lims.interfaces.field import IUIDReferenceField as IATUIDReference
 from DateTime import DateTime
 from Products.CMFPlone.utils import safe_callable
@@ -232,8 +231,6 @@ class SuperModel(object):
             return True
         if IDXUIDReference.providedBy(field):
             # DX-specific UIDReferenceField
-            return True
-        if IARAnalysesField.providedBy(field):
             return True
         return False
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request does no longer consider `IARAnalysesField` as a reference-like field. 

With https://github.com/senaite/senaite.core/pull/2603 , the `getRaw` field no longer relies on an object attribute, but on the `get` directly, that return brains. Is better to create a SuperModel with a brain than with a UID, cause with the former we can at least access to the metadata fields directly  without having to wake up the object.

## Current behavior before PR

`IARAnalysesField` is considered a reference-like field

## Desired behavior after PR is merged

`IARanalsyesField` is no longer considered a reference-like field

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
